### PR TITLE
Fix app start

### DIFF
--- a/src/cryoet_data_portal_dashboard/app.py
+++ b/src/cryoet_data_portal_dashboard/app.py
@@ -145,8 +145,8 @@ def render_page_content(pathname):
 
 
 def main():
-    app.run_server(debug=True)
+    app.run(debug=True)
 
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
`app.run_server` has been replaced with `app.run`, see traceback:

```
Traceback (most recent call last):                                                                                                                                                                         
  File "<frozen runpy>", line 198, in _run_module_as_main                                                                                                                                                  
  File "<frozen runpy>", line 88, in _run_code                                                                                                                                                             
  File "/home/pape/Desktop/applications/ki-forschungsgruppe/figures/cryoet-data-portal-dashboard/src/cryoet_data_portal_dashboard/app.py", line 152, in <module>                                           
    main()                                                                                                                                                                                                 
    ~~~~^^                                                                                                                                                                                                 
  File "/home/pape/Desktop/applications/ki-forschungsgruppe/figures/cryoet-data-portal-dashboard/src/cryoet_data_portal_dashboard/app.py", line 148, in main                                               
    app.run_server(debug=True)                                                                                                                                                                             
    ^^^^^^^^^^^^^^                                                                                                                                                                                         
  File "/home/pape/micromamba/envs/dashboard/lib/python3.13/site-packages/dash/_obsolete.py", line 22, in __getattr__                                                                                      
    raise err.exc(err.message)                                                                                                                                                                             
dash.exceptions.ObsoleteAttributeException: app.run_server has been replaced by app.run
```